### PR TITLE
Invalidate cache when guardrail version changes

### DIFF
--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -9,5 +9,5 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 // Dependencies
 libraryDependencies += "dev.guardrail" %% "guardrail" % "0.64.4"
 
-buildInfoKeys := Seq[BuildInfoKey](organization)
+buildInfoKeys := Seq[BuildInfoKey](organization, version)
 buildInfoPackage := "dev.guardrail.sbt"

--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -177,7 +177,7 @@ trait AbstractGuardrailPlugin { self: AutoPlugin =>
         }
 
         def calcResult() =
-          GuardrailAnalysis(Tasks.guardrailTask(runner)(tasks, sources.head).toList)
+          GuardrailAnalysis(BuildInfo.version, Tasks.guardrailTask(runner)(tasks, sources.head).toList)
 
         val cachedResult = Tracked.lastOutput[Unit, GuardrailAnalysis](streams.cacheStoreFactory.sub("guardrail").sub(kind).make("last")) {
           (_, prev) =>

--- a/modules/core/src/main/scala/GuardrailAnalysis.scala
+++ b/modules/core/src/main/scala/GuardrailAnalysis.scala
@@ -5,17 +5,17 @@ import _root_.sbt._
 import _root_.sbt.util.CacheImplicits._
 import sjsonnew.{ :*:, LList, LNil}
 
-case class GuardrailAnalysis(products: List[java.io.File]) {
+case class GuardrailAnalysis(guardrailVersion: String, products: List[java.io.File]) {
   def ++(that: GuardrailAnalysis): GuardrailAnalysis =
-    GuardrailAnalysis(products ++ that.products)
+    GuardrailAnalysis(guardrailVersion, products ++ that.products)
 }
 object GuardrailAnalysis {
 
-  private val from: (List[java.io.File] :*: LNil) => GuardrailAnalysis = {
-    case ((_, in) :*: LNil) => GuardrailAnalysis(in)
+  private val from: (String :*: List[java.io.File] :*: LNil) => GuardrailAnalysis = {
+    case ((_, version) :*: (_, in) :*: LNil) => GuardrailAnalysis(version, in)
   }
 
   implicit val analysisIso = LList.iso(
-    { a: GuardrailAnalysis => ("products", a.products) :*: LNil },
+    { a: GuardrailAnalysis => ("guardrailVersion", a.guardrailVersion) :*: ("products", a.products) :*: LNil },
     { from })
 }


### PR DESCRIPTION
I had to add `BuildInfo` anyway in order to do the org change warning, so doing a different take on #117.

Thank you for the contribution, @lolgab!