### PR TITLE
Bumping libs

### DIFF
--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -8,19 +8,18 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
 // Dependencies
 libraryDependencies ++= Seq(
-  "dev.guardrail" %% "guardrail" % "0.69.0",
-  "dev.guardrail" %% "guardrail-core" % "0.68.1",
-  "dev.guardrail" %% "guardrail-java-support" % "0.67.2",
-  "dev.guardrail" %% "guardrail-scala-support" % "0.68.1",
+  "dev.guardrail" %% "guardrail" % "0.70.0",
+  "dev.guardrail" %% "guardrail-core" % "0.69.0",
+  "dev.guardrail" %% "guardrail-java-support" % "0.68.0",
+  "dev.guardrail" %% "guardrail-scala-support" % "0.69.0",
 
   // Pending removal, before we hit 1.0.0, as per https://github.com/guardrail-dev/guardrail/issues/1195
-  "dev.guardrail" %% "guardrail-java-async-http" % "0.67.1",
-  "dev.guardrail" %% "guardrail-java-dropwizard" % "0.67.1",
-  "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.67.1",
-  "dev.guardrail" %% "guardrail-scala-akka-http" % "0.69.0",
-  "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.67.1",
-  "dev.guardrail" %% "guardrail-scala-endpoints" % "0.67.1",
-  "dev.guardrail" %% "guardrail-scala-http4s" % "0.69.0"
+  "dev.guardrail" %% "guardrail-java-async-http" % "0.68.0",
+  "dev.guardrail" %% "guardrail-java-dropwizard" % "0.68.0",
+  "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.68.0",
+  "dev.guardrail" %% "guardrail-scala-akka-http" % "0.70.0",
+  "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.68.0",
+  "dev.guardrail" %% "guardrail-scala-http4s" % "0.70.0"
 )
 
 buildInfoKeys := Seq[BuildInfoKey](organization, version)

--- a/src/sbt-test/sbt-guardrail/java-codegen-app/build.sbt
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/build.sbt
@@ -23,5 +23,6 @@ libraryDependencies ++= Seq(
   "org.asynchttpclient"               % "async-http-client"         % "2.10.4",
   "javax.annotation"                  %  "javax.annotation-api"     % javaxAnnotationVersion, // for jdk11
   "javax.xml.bind"                    % "jaxb-api"                  % "2.3.1",
-  "org.scalatest"                    %% "scalatest"                 % "3.0.8" % "test"
+  "org.scala-lang.modules"           %% "scala-java8-compat"        % "1.0.2",
+  "org.scalatest"                    %% "scalatest"                 % "3.0.8" % Test
 )

--- a/src/sbt-test/sbt-guardrail/java-codegen-app/src/main/scala/helloworld/Hello.scala
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/src/main/scala/helloworld/Hello.scala
@@ -1,10 +1,40 @@
 package helloworld
 
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+
 import com.example.clients.petstore.user.UserClient
+import org.asynchttpclient.Response
 
 object Hello {
+  def resp(code: (Int, String)): Response = new Response {
+    def getContentType(): String = null
+    def getCookies(): java.util.List[io.netty.handler.codec.http.cookie.Cookie] = null
+    def getHeader(x$1: CharSequence): String = null
+    def getHeaders(): io.netty.handler.codec.http.HttpHeaders = null
+    def getHeaders(x$1: CharSequence): java.util.List[String] = null
+    def getLocalAddress(): java.net.SocketAddress = null
+    def getRemoteAddress(): java.net.SocketAddress = null
+    def getResponseBody(): String = null
+    def getResponseBody(x$1: java.nio.charset.Charset): String = null
+    def getResponseBodyAsByteBuffer(): java.nio.ByteBuffer = null
+    def getResponseBodyAsBytes(): Array[Byte] = null
+    def getResponseBodyAsStream(): java.io.InputStream = null
+    def getStatusCode(): Int = code._1
+    def getStatusText(): String = code._2
+    def getUri(): org.asynchttpclient.uri.Uri = null
+    def hasResponseBody(): Boolean = false
+    def hasResponseHeaders(): Boolean = false
+    def hasResponseStatus(): Boolean = true
+    def isRedirected(): Boolean = false
+  }
+
   def buildUserClient = {
-    new UserClient.Builder().build
+    new UserClient.Builder()
+      .withHttpClient( req =>
+        Future.successful(resp((302, "Found"))).toJava
+      )
+      .build()
   }
 
 }


### PR DESCRIPTION
New fields added to support generated authentication schemes, initially as part of http4s, necessitated bincompat breakage. Bump everything.