### PR TITLE
Typo, tagsFromPackage

### DIFF
--- a/modules/core/src/main/scala/Keys.scala
+++ b/modules/core/src/main/scala/Keys.scala
@@ -44,5 +44,5 @@ object Keys {
   def codingOptionalLegacy: CodingConfig = CodingConfig.OptionalLegacy
 
   def tagsAreIgnored: Context.TagsBehaviour = Context.TagsAreIgnored
-  def tagsFromPackage: Context.TagsBehaviour = Context.PackageFromTags
+  def tagsAsPackage: Context.TagsBehaviour = Context.PackageFromTags
 }


### PR DESCRIPTION
The issue is `Context.TagsAreIgnored` and `Context.PackageFromTags` make sense as members of `Context`, but for top-level sbt keys, it would be good for both to have the same textual prefix, matching the parameter name, for ergonomics.

```scala
ScalaClient(..., tagsBehaviour=tagsAreIgnored),
ScalaClient(..., tagsBehaviour=tagsAsPackage),
...
```

`tagsFromPackage` doesn't make sense, since it's the other way around