### PR TITLE
Renaming SwaggerConfigValue -> GuardrailConfigValue

### DIFF
--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -72,15 +72,15 @@ trait AbstractGuardrailPlugin extends GuardrailRunner { self: AutoPlugin =>
     def apply(
       specPath: java.io.File,
       pkg: String = "swagger",
-      dto: Keys.SwaggerConfigValue[String] = Keys.Default,
-      framework: Keys.SwaggerConfigValue[String] = Keys.Default,
-      tracing: Keys.SwaggerConfigValue[Boolean] = Keys.Default,
-      modules: Keys.SwaggerConfigValue[List[String]] = Keys.Default,
-      imports: Keys.SwaggerConfigValue[List[String]] = Keys.Default,
-      encodeOptionalAs: Keys.SwaggerConfigValue[CodingConfig] = Keys.Default,
-      decodeOptionalAs: Keys.SwaggerConfigValue[CodingConfig] = Keys.Default,
-      customExtraction: Keys.SwaggerConfigValue[Boolean] = Keys.Default,
-      tagsBehaviour: Keys.SwaggerConfigValue[ContextImpl.TagsBehaviour] = Keys.Default,
+      dto: Keys.GuardrailConfigValue[String] = Keys.Default,
+      framework: Keys.GuardrailConfigValue[String] = Keys.Default,
+      tracing: Keys.GuardrailConfigValue[Boolean] = Keys.Default,
+      modules: Keys.GuardrailConfigValue[List[String]] = Keys.Default,
+      imports: Keys.GuardrailConfigValue[List[String]] = Keys.Default,
+      encodeOptionalAs: Keys.GuardrailConfigValue[CodingConfig] = Keys.Default,
+      decodeOptionalAs: Keys.GuardrailConfigValue[CodingConfig] = Keys.Default,
+      customExtraction: Keys.GuardrailConfigValue[Boolean] = Keys.Default,
+      tagsBehaviour: Keys.GuardrailConfigValue[ContextImpl.TagsBehaviour] = Keys.Default,
     ): Types.Args = (language, impl(
       kind = kind,
       specPath = Some(specPath),
@@ -98,20 +98,20 @@ trait AbstractGuardrailPlugin extends GuardrailRunner { self: AutoPlugin =>
     ))
 
     def defaults(
-      pkg: Keys.SwaggerConfigValue[String] = Keys.Default,
-      dto: Keys.SwaggerConfigValue[String] = Keys.Default,
-      framework: Keys.SwaggerConfigValue[String] = Keys.Default,
-      tracing: Keys.SwaggerConfigValue[Boolean] = Keys.Default,
-      modules: Keys.SwaggerConfigValue[List[String]] = Keys.Default,
-      imports: Keys.SwaggerConfigValue[List[String]] = Keys.Default,
-      encodeOptionalAs: Keys.SwaggerConfigValue[CodingConfig] = Keys.Default,
-      decodeOptionalAs: Keys.SwaggerConfigValue[CodingConfig] = Keys.Default,
-      customExtraction: Keys.SwaggerConfigValue[Boolean] = Keys.Default,
-      tagsBehaviour: Keys.SwaggerConfigValue[ContextImpl.TagsBehaviour] = Keys.Default,
+      pkg: Keys.GuardrailConfigValue[String] = Keys.Default,
+      dto: Keys.GuardrailConfigValue[String] = Keys.Default,
+      framework: Keys.GuardrailConfigValue[String] = Keys.Default,
+      tracing: Keys.GuardrailConfigValue[Boolean] = Keys.Default,
+      modules: Keys.GuardrailConfigValue[List[String]] = Keys.Default,
+      imports: Keys.GuardrailConfigValue[List[String]] = Keys.Default,
+      encodeOptionalAs: Keys.GuardrailConfigValue[CodingConfig] = Keys.Default,
+      decodeOptionalAs: Keys.GuardrailConfigValue[CodingConfig] = Keys.Default,
+      customExtraction: Keys.GuardrailConfigValue[Boolean] = Keys.Default,
+      tagsBehaviour: Keys.GuardrailConfigValue[ContextImpl.TagsBehaviour] = Keys.Default,
 
       // Deprecated parameters
-      packageName: Keys.SwaggerConfigValue[String] = Keys.Default,
-      dtoPackage: Keys.SwaggerConfigValue[String] = Keys.Default
+      packageName: Keys.GuardrailConfigValue[String] = Keys.Default,
+      dtoPackage: Keys.GuardrailConfigValue[String] = Keys.Default
     ): Types.Args = (language, impl(
       kind = kind,
       specPath = None,

--- a/modules/core/src/main/scala/Keys.scala
+++ b/modules/core/src/main/scala/Keys.scala
@@ -23,13 +23,13 @@ object CodingConfig {
 }
 
 object Keys {
-  sealed trait SwaggerConfigValue[T] { def toOption: Option[T] }
-  def Default[T]: SwaggerConfigValue[T] = SwaggerConfigValue.Default()
-  def Value[T](value: T): SwaggerConfigValue[T] = SwaggerConfigValue.Value(value)
-  object SwaggerConfigValue {
-    case class Default[T]() extends SwaggerConfigValue[T] { def toOption = None }
-    case class Value[T](value: T) extends SwaggerConfigValue[T] { def toOption = Some(value) }
-    implicit def liftSwaggerConfigValue[T](value: T): SwaggerConfigValue[T] = Value(value)
+  sealed trait GuardrailConfigValue[T] { def toOption: Option[T] }
+  def Default[T]: GuardrailConfigValue[T] = GuardrailConfigValue.Default()
+  def Value[T](value: T): GuardrailConfigValue[T] = GuardrailConfigValue.Value(value)
+  object GuardrailConfigValue {
+    case class Default[T]() extends GuardrailConfigValue[T] { def toOption = None }
+    case class Value[T](value: T) extends GuardrailConfigValue[T] { def toOption = Some(value) }
+    implicit def liftGuardrailConfigValue[T](value: T): GuardrailConfigValue[T] = Value(value)
   }
 
   val guardrailDefaults = SettingKey[Args]("guardrail-defaults")


### PR DESCRIPTION
Holdover from when this was `"com.twilio" %% "swagger-codegen" % ...`