### PR TITLE
Exposing coding and tags values

### DIFF
--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -163,6 +163,13 @@ trait AbstractGuardrailPlugin extends GuardrailRunner { self: AutoPlugin =>
       val kind = CodegenTargetImpl.Server
       val language = "java"
     }
+
+    def codingRequiredNullable = Keys.codingRequiredNullable
+    def codingOptional = Keys.codingOptional
+    def codingOptionalLegacy = Keys.codingOptionalLegacy
+
+    def tagsAreIgnored = Keys.tagsAreIgnored
+    def tagsAsPackage = Keys.tagsAsPackage
   }
 
   private def cachedGuardrailTask(projectName: String, scope: String, scalaBinaryVersion: String)(kind: String, streams: _root_.sbt.Keys.TaskStreams)(tasks: List[(String, Args)], sources: Seq[java.io.File]) = {


### PR DESCRIPTION
Exposing parameter values for

```scala
      encodeOptionalAs: Option[CodingConfig],
      decodeOptionalAs: Option[CodingConfig],
      tagsBehaviour: Option[ContextImpl.TagsBehaviour]
```

Usage:

```scala
ScalaClient(..., encodeOptionalAs=codingRequiredNullable, tagsBehaviour=tagsAsPackage)
```