### PR TITLE
Update guardrail modules to use SPI

### DIFF
--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -8,18 +8,18 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
 // Dependencies
 libraryDependencies ++= Seq(
-  "dev.guardrail" %% "guardrail" % "0.70.0",
-  "dev.guardrail" %% "guardrail-core" % "0.69.0",
-  "dev.guardrail" %% "guardrail-java-support" % "0.68.0",
-  "dev.guardrail" %% "guardrail-scala-support" % "0.69.1",
+  "dev.guardrail" %% "guardrail" % "0.71.0",
+  "dev.guardrail" %% "guardrail-core" % "0.70.0",
+  "dev.guardrail" %% "guardrail-java-support" % "0.69.0",
+  "dev.guardrail" %% "guardrail-scala-support" % "0.70.0",
 
   // Pending removal, before we hit 1.0.0, as per https://github.com/guardrail-dev/guardrail/issues/1195
-  "dev.guardrail" %% "guardrail-java-async-http" % "0.68.0",
-  "dev.guardrail" %% "guardrail-java-dropwizard" % "0.68.0",
-  "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.68.0",
-  "dev.guardrail" %% "guardrail-scala-akka-http" % "0.70.0",
-  "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.68.0",
-  "dev.guardrail" %% "guardrail-scala-http4s" % "0.70.0"
+  "dev.guardrail" %% "guardrail-java-async-http" % "0.69.0",
+  "dev.guardrail" %% "guardrail-java-dropwizard" % "0.69.0",
+  "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.69.0",
+  "dev.guardrail" %% "guardrail-scala-akka-http" % "0.71.0",
+  "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.69.0",
+  "dev.guardrail" %% "guardrail-scala-http4s" % "0.71.0"
 )
 
 buildInfoKeys := Seq[BuildInfoKey](organization, version)


### PR DESCRIPTION
Upgrading to the first version of sbt-guardrail with the SPI module system.

The last vestige of the old module system remains in

```scala
def languages = GeneratorMappings.defaultLanguages
```

which can be fixed by adding an SPI loader for `CoreTermInterp` as well. Once that's done, the language registration can be entirely based on which modules you have on the classpath.

There should be no change in functionality for the code generator itself in this release.