### PR TITLE
fix: use FileFunction.cached

### DIFF
--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -1,7 +1,7 @@
 package dev.guardrail
 package sbt
 
-import _root_.sbt.{Keys => SbtKeys, _}
+import _root_.sbt.{Keys => SbtKeys, Types => _, _}
 import _root_.sbt.plugins.JvmPlugin
 import dev.guardrail.runner.GuardrailRunner
 import dev.guardrail.terms.protocol.PropertyRequirement
@@ -189,7 +189,7 @@ trait AbstractGuardrailPlugin extends GuardrailRunner { self: AutoPlugin =>
 
   private def cachedGuardrailTask(projectName: String, scope: String, scalaBinaryVersion: String)(kind: String, streams: _root_.sbt.Keys.TaskStreams)(tasks: List[(String, Args)], sources: Seq[java.io.File]) = {
     val inputFiles = tasks.flatMap(_._2.specPath).map(file(_)).toSet
-    val cacheDir = streams.cacheDirectory / "guardrail"
+    val cacheDir = streams.cacheDirectory / "guardrail" / scalaBinaryVersion / kind
 
     val cachedFn = _root_.sbt.util.FileFunction
       .cached(cacheDir, inStyle = FilesInfo.hash, outStyle = FilesInfo.hash) {

--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -188,6 +188,10 @@ trait AbstractGuardrailPlugin extends GuardrailRunner { self: AutoPlugin =>
   }
 
   private def cachedGuardrailTask(projectName: String, scope: String, scalaBinaryVersion: String)(kind: String, streams: _root_.sbt.Keys.TaskStreams)(tasks: List[(String, Args)], sources: Seq[java.io.File]) = {
+    if (BuildInfo.organization == "com.twilio" && tasks.nonEmpty) {
+      streams.log.warn(s"""${projectName} / ${scope}: sbt-guardrail has changed organizations! Please change "com.twilio" to "dev.guardrail" to continue receiving updates""")
+    }
+    
     val inputFiles = tasks.flatMap(_._2.specPath).map(file(_)).toSet
     val cacheDir = streams.cacheDirectory / "guardrail" / scalaBinaryVersion / kind
 

--- a/modules/core/src/main/scala/GuardrailAnalysis.scala
+++ b/modules/core/src/main/scala/GuardrailAnalysis.scala
@@ -5,13 +5,13 @@ import _root_.sbt._
 import _root_.sbt.util.CacheImplicits._
 import sjsonnew.{ :*:, LList, LNil}
 
-case class GuardrailAnalysis(guardrailVersion: String, products: List[java.io.File]) {
+case class GuardrailAnalysis(guardrailVersion: String, products: Set[java.io.File]) {
   def ++(that: GuardrailAnalysis): GuardrailAnalysis =
     GuardrailAnalysis(guardrailVersion, products ++ that.products)
 }
 object GuardrailAnalysis {
 
-  private val from: (String :*: List[java.io.File] :*: LNil) => GuardrailAnalysis = {
+  private val from: (String :*: Set[java.io.File] :*: LNil) => GuardrailAnalysis = {
     case ((_, version) :*: (_, in) :*: LNil) => GuardrailAnalysis(version, in)
   }
 

--- a/modules/core/src/main/scala/Tasks.scala
+++ b/modules/core/src/main/scala/Tasks.scala
@@ -16,7 +16,7 @@ class CodegenFailedException extends FeedbackProvidedException
 object Tasks {
   def guardrailTask(
     runner: Map[String,NonEmptyList[ArgsImpl]] => Target[List[Path]]
-  )(tasks: List[Types.Args], sourceDir: File): Seq[File] = {
+  )(tasks: List[Types.Args], sourceDir: File): Set[File] = {
     // swagger-parser uses SPI to find extensions on the classpath (by default, only the OAPI2 -> OAPI3 converter)
     // See https://github.com/swagger-api/swagger-parser#extensions
     // That being said, Scala's classloader seems to have some issues finding SPI resources:
@@ -27,66 +27,67 @@ object Tasks {
     val oldClassLoader = Thread.currentThread().getContextClassLoader()
     Thread.currentThread().setContextClassLoader(classOf[SwaggerParserExtension].getClassLoader)
 
-    val preppedTasks: Map[String, NonEmptyList[ArgsImpl]] = tasks.foldLeft(Map.empty[String, NonEmptyList[ArgsImpl]]) { case (acc, (language, args)) =>
-      val prepped = args.copy(outputPath=Some(sourceDir.getPath))
-      acc.updated(language, acc.get(language).fold(NonEmptyList.one(prepped))(_ :+ prepped))
-    }
+    try {
+      val preppedTasks: Map[String, NonEmptyList[ArgsImpl]] = tasks.foldLeft(Map.empty[String, NonEmptyList[ArgsImpl]]) { case (acc, (language, args)) =>
+        val prepped = args.copy(outputPath=Some(sourceDir.getPath))
+        acc.updated(language, acc.get(language).fold(NonEmptyList.one(prepped))(_ :+ prepped))
+      }
 
-    val /*(logger,*/ paths/*)*/ =
-      runner
-        .apply(preppedTasks)
-        .fold[List[java.nio.file.Path]]({
-          case MissingArg(args, Error.ArgName(arg)) =>
-            println(s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
-            throw new CodegenFailedException()
-          case MissingDependency(name) =>
-            println(s"""${AnsiColor.RED}Missing dependency:${AnsiColor.RESET} ${AnsiColor.BOLD}libraryDependencies += "dev.guardrail" %% "${name}" % "<check latest version>"${AnsiColor.RESET}""")
-            throw new CodegenFailedException()
-          case NoArgsSpecified =>
-            List.empty
-          case NoFramework =>
-            println(s"${AnsiColor.RED}No framework specified${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case PrintHelp =>
-            List.empty
-          case UnknownArguments(args) =>
-            println(s"${AnsiColor.RED}Unknown arguments: ${args.mkString(" ")}${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case UnparseableArgument(name, message) =>
-            println(s"${AnsiColor.RED}Unparseable argument ${name}: ${message}${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case UnknownFramework(name) =>
-            println(s"${AnsiColor.RED}Unknown framework specified: ${name}${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case RuntimeFailure(message) =>
-            println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
-            throw new CodegenFailedException()
-          case UserError(message) =>
-            println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
-            throw new CodegenFailedException()
-          case MissingModule(section, choices) =>
-            println(s"${AnsiColor.RED}Error: Missing module ${section}. Options are: ${choices.mkString(", ")}${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case ModuleConflict(section) =>
-            println(s"${AnsiColor.RED}Error: Too many modules specified for ${section}${AnsiColor.RESET}")
-            throw new CodegenFailedException()
-          case UnspecifiedModules(choices) =>
-            val result =
-              choices.toSeq.sortBy(_._1).foldLeft(Seq.empty[String]) { case (acc, (module, choices)) =>
-                val nextLabel = Option(choices).filter(_.nonEmpty).fold("<no choices found>")(_.toSeq.sorted.mkString(", "))
-                acc :+ s"  ${AnsiColor.BOLD}${AnsiColor.WHITE}${module}:${AnsiColor.RESET} [${AnsiColor.BLUE}${nextLabel}${AnsiColor.RESET}]"
-              }
-            println(s"${AnsiColor.RED}Unsatisfied module(s):${AnsiColor.RESET}")
-            result.foreach(println)
-            throw new CodegenFailedException()
-          case UnusedModules(unused) =>
-            println(s"${AnsiColor.RED}Unused modules specified:${AnsiColor.RESET} ${unused.toList.mkString(", ")}")
-            throw new CodegenFailedException()
-        }, identity)
-        //.runEmpty
+      val /*(logger,*/ paths/*)*/ =
+        runner
+          .apply(preppedTasks)
+          .fold[List[java.nio.file.Path]]({
+            case MissingArg(args, Error.ArgName(arg)) =>
+              println(s"${AnsiColor.RED}Missing argument:${AnsiColor.RESET} ${AnsiColor.BOLD}${arg}${AnsiColor.RESET} (In block ${args})")
+              throw new CodegenFailedException()
+            case MissingDependency(name) =>
+              println(s"""${AnsiColor.RED}Missing dependency:${AnsiColor.RESET} ${AnsiColor.BOLD}libraryDependencies += "dev.guardrail" %% "${name}" % "<check latest version>"${AnsiColor.RESET}""")
+              throw new CodegenFailedException()
+            case NoArgsSpecified =>
+              List.empty
+            case NoFramework =>
+              println(s"${AnsiColor.RED}No framework specified${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case PrintHelp =>
+              List.empty
+            case UnknownArguments(args) =>
+              println(s"${AnsiColor.RED}Unknown arguments: ${args.mkString(" ")}${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case UnparseableArgument(name, message) =>
+              println(s"${AnsiColor.RED}Unparseable argument ${name}: ${message}${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case UnknownFramework(name) =>
+              println(s"${AnsiColor.RED}Unknown framework specified: ${name}${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case RuntimeFailure(message) =>
+              println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
+              throw new CodegenFailedException()
+            case UserError(message) =>
+              println(s"${AnsiColor.RED}Error:${AnsiColor.RESET}${message}")
+              throw new CodegenFailedException()
+            case MissingModule(section, choices) =>
+              println(s"${AnsiColor.RED}Error: Missing module ${section}. Options are: ${choices.mkString(", ")}${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case ModuleConflict(section) =>
+              println(s"${AnsiColor.RED}Error: Too many modules specified for ${section}${AnsiColor.RESET}")
+              throw new CodegenFailedException()
+            case UnspecifiedModules(choices) =>
+              val result =
+                choices.toSeq.sortBy(_._1).foldLeft(Seq.empty[String]) { case (acc, (module, choices)) =>
+                  val nextLabel = Option(choices).filter(_.nonEmpty).fold("<no choices found>")(_.toSeq.sorted.mkString(", "))
+                  acc :+ s"  ${AnsiColor.BOLD}${AnsiColor.WHITE}${module}:${AnsiColor.RESET} [${AnsiColor.BLUE}${nextLabel}${AnsiColor.RESET}]"
+                }
+              println(s"${AnsiColor.RED}Unsatisfied module(s):${AnsiColor.RESET}")
+              result.foreach(println)
+              throw new CodegenFailedException()
+            case UnusedModules(unused) =>
+              println(s"${AnsiColor.RED}Unused modules specified:${AnsiColor.RESET} ${unused.toList.mkString(", ")}")
+              throw new CodegenFailedException()
+          }, identity)
+          //.runEmpty
 
-    Thread.currentThread().setContextClassLoader(oldClassLoader)
-    paths.map(_.toFile).distinct
+      paths.map(_.toFile).toSet
+    } finally Thread.currentThread().setContextClassLoader(oldClassLoader)
   }
 
   def watchSources(tasks: List[Types.Args]): Seq[WatchSource] = {


### PR DESCRIPTION
hello 🤠 I have been investigating an issue in our pipeline that happens between our `build` stage where we generate sources and compile, and the `test` stage where we run tests. We are getting IO errors during the `test` stage that look like this:

```
sbt:hello-world> test
[info] compiling 12 Scala sources to /Users/regiskuckaertz/code/guard1/hw2/target/scala-2.13/classes ...
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/AkkaHttpImplicits.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/AkkaHttpImplicits.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/Client.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/Client.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/Implicits.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/Implicits.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/ApiResponse.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/ApiResponse.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Category.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Category.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Order.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Order.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Pet.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Pet.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Tag.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/Tag.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/User.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/User.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/package.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/definitions/package.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] IO error while decoding /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/support/Presence.scala with UTF-8: /Users/regiskuckaertz/code/guard1/hello-world/target/scala-2.13/src_managed/main/com/regiskuckaertz/support/Presence.scala (No such file or directory)
[error] Please try specifying another one using the -encoding option
[error] 11 errors found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 2 s, completed 10 Jun 2023, 18:46:11%                                                                                                                                                     
```

I noticed the paths listed in the errors were the absolute paths of the sources generated during the `compile` stage. Of course they don't exist anymore since the `build` stage runs in a separate runner with a different base directory. The only place I could think of where absolute paths would be persisted on disk was in the SBT caching (the `streams` task). It seems that something shady is happening with `Tracked.inputChanged`, as after replacing with `FileFunction.cached` I'm unable to reproduce the issue. To reproduce here is what I did:

- create a new sbt project under directory `hello1`, with an openapi spec, and a test using the generated code
- sbt clean compile
- exit the project
- rename `hello1` to `hello2`
- sbt test

That would fail consistently, but not anymore.

I also took the liberty of wrapping the task with a `try/finally` to make sure the classloader is restored in case an exception is thrown.