### PR TITLE
Delete direct modules in favor of consumer-side module management

### DIFF
--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -9,16 +9,6 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 // Dependencies
 libraryDependencies ++= Seq(
   "dev.guardrail" %% "guardrail-core" % "0.75.3",
-  "dev.guardrail" %% "guardrail-java-support" % "0.73.1",
-  "dev.guardrail" %% "guardrail-scala-support" % "0.75.3",
-
-  // Pending removal, before we hit 1.0.0, as per https://github.com/guardrail-dev/guardrail/issues/1195
-  "dev.guardrail" %% "guardrail-java-async-http" % "0.72.0",
-  "dev.guardrail" %% "guardrail-java-dropwizard" % "0.72.0",
-  "dev.guardrail" %% "guardrail-java-spring-mvc" % "0.71.2",
-  "dev.guardrail" %% "guardrail-scala-akka-http" % "0.76.0",
-  "dev.guardrail" %% "guardrail-scala-dropwizard" % "0.72.0",
-  "dev.guardrail" %% "guardrail-scala-http4s" % "0.76.1",
   "org.snakeyaml" % "snakeyaml-engine" % "2.7"
 )
 

--- a/src/sbt-test/sbt-guardrail/java-codegen-app/project/plugins.sbt
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/project/plugins.sbt
@@ -6,4 +6,6 @@
   else addSbtPlugin("dev.guardrail" % "sbt-guardrail" % pluginVersion)
 }
 
-// libraryDependencies += "dev.guardrail" %% "guardrail-java-dropwizard" % "<once 1.0.0 dep changes propagate>"
+libraryDependencies += "dev.guardrail" %% "guardrail-java-support" % "0.73.1"
+libraryDependencies += "dev.guardrail" %% "guardrail-java-async-http" % "0.72.0"
+libraryDependencies += "dev.guardrail" %% "guardrail-java-dropwizard" % "0.72.0"

--- a/src/sbt-test/sbt-guardrail/scala-client-codegen-app/project/plugins.sbt
+++ b/src/sbt-test/sbt-guardrail/scala-client-codegen-app/project/plugins.sbt
@@ -6,4 +6,5 @@
   else addSbtPlugin("dev.guardrail" % "sbt-guardrail" % pluginVersion)
 }
 
-// libraryDependencies += "dev.guardrail" %% "guardrail-scala-akka-http" % "<once 1.0.0 dep changes propagate>"
+libraryDependencies += "dev.guardrail" %% "guardrail-scala-support" % "0.75.3"
+libraryDependencies += "dev.guardrail" %% "guardrail-scala-akka-http" % "0.76.0"


### PR DESCRIPTION
With direct module dependencies, scala-steward can bump individual modules using a semver strategy instead of a monolithic version number obscuring actual changes under the hood.

Instead of

```scala
addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "0.75.2")
```

add the explicit modules you need:

```scala
addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "1.0.0")
libraryDependencies += "dev.guardrail" %% "guardrail-scala-support" % "1.0.0"
libraryDependencies += "dev.guardrail" %% "guardrail-scala-http4s" % "1.0.0"
```

This should save CI cycles since you'll only get version bumps for code **you actually use**.